### PR TITLE
Fix async logic in loadJS

### DIFF
--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿function loadJs(sourceUrl) {
+﻿async function loadJs(sourceUrl) {
 	if (sourceUrl.Length == 0) {
 		console.error("Invalid source URL");
 		return;

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,20 +1,27 @@
-﻿async function loadJs(sourceUrl) {
-	if (sourceUrl.Length == 0) {
-		console.error("Invalid source URL");
-		return;
-	}
+async function loadJs(sourceUrl) {
+    if (sourceUrl.Length === 0) {
+        console.error("Invalid source URL");
+        return;
+    }
 
-	var tag = document.createElement('script');
-	tag.src = sourceUrl;
-	tag.type = "text/javascript";
+    var tag = document.createElement('script');
 
-	tag.onload = function () {
-		console.log("Script loaded successfully");
-	}
+    var promise = new Promise((resolve, reject) => {
 
-	tag.onerror = function () {
-		console.error("Failed to load script");
-	}
+        tag.src = sourceUrl;
+        tag.type = "text/javascript";
+        tag.onload = resolve();
 
-	document.body.appendChild(tag);
+        tag.onload = function () {
+            console.log("Script loaded successfully");
+        }
+
+        tag.onerror = function () {
+            console.error("Failed to load script");
+        }
+
+        document.body.appendChild(tag);
+    });
+
+    await promise;
 }


### PR DESCRIPTION
Having `await` keyword in Blazor is useless unless your accommodating js function is also async. This could result in a situation where the next blazor line runs before the JS script is truly finished loading. If you're trying to access a script in that function, you will have a crash.

The new `site.js` file uses async / await and promises to resolve only once the js script is loaded (using the onload function to resolve a promise before returning).

Of course, this could create a block if a script takes a long time to load. Tested on my machine to work on a locally run blazor server.